### PR TITLE
feat: アーキテクチャドキュメントに詳細概念図を追加

### DIFF
--- a/docs/00_全体/06_アーキテクチャ.md
+++ b/docs/00_全体/06_アーキテクチャ.md
@@ -82,6 +82,120 @@ graph TD
 
 ---
 
+### 詳細概念図
+
+```mermaid
+flowchart TD
+%% UI層
+subgraph UILayer
+U1["個別画面 (React/Next.js)"]
+U2["共通画面 (React/Material-UI)"]
+end
+
+%% APIゲートウェイ層
+subgraph APIGatewayLayer
+AGW["APIゲートウェイ (認証・認可/ルーティング/監査)"]
+end
+
+%% 共通基盤API層
+subgraph CommonAPILayer
+CAPI["共通基盤API (Rust/Go/Python)"]
+Auth["認証認可サービス"]
+Conf["設定管理サービス"]
+Log["ロギング・監査サービス"]
+MCPGW["MCP連携ゲートウェイ"]
+end
+
+%% 個別API層
+subgraph IndividualAPILayer
+IAPI["個別API (Node.js/.NET/Java)"]
+end
+
+%% 個別基盤層
+subgraph IndividualPlatformLayer
+IBP["個別基盤サービス (業務ルール共通化)"]
+end
+
+%% データ層
+subgraph DataLayer
+DB1["PostgreSQL"]
+DB2["MongoDB"]
+ExtAPI["外部API/サービス"]
+end
+
+%% AI連携層
+subgraph AILinkLayer
+MCP["MCP (Model Context Protocol)"]
+AIM["AIモデル/AIサービス"]
+end
+
+%% インフラ層
+subgraph InfraLayer
+K8s["Kubernetes"]
+Cloud["クラウド基盤 (AWS/Azure/GCP)"]
+CI["CI/CD (GitHub Actions)"]
+Vault["シークレット管理"]
+Mon["監視/メトリクス (Prometheus/Grafana)"]
+end
+
+%% UI→API
+U1 -->|REST/GraphQL/WebSocket| AGW
+U2 -->|REST/GraphQL/WebSocket| AGW
+AGW -->|認証・認可| Auth
+AGW -->|APIルーティング| CAPI
+AGW -->|APIルーティング| IAPI
+
+%% 共通基盤API
+CAPI -->|認証認可| Auth
+CAPI -->|設定管理| Conf
+CAPI -->|ロギング| Log
+CAPI -->|MCP連携| MCPGW
+CAPI -->|業務API呼び出し| IAPI
+CAPI -->|個別基盤呼び出し| IBP
+CAPI -->|DBアクセス| DB1
+CAPI -->|DBアクセス| DB2
+CAPI -->|外部API| ExtAPI
+
+%% 個別API/基盤
+IAPI -->|個別基盤呼び出し| IBP
+IAPI -->|DBアクセス| DB1
+IAPI -->|DBアクセス| DB2
+IBP -->|DBアクセス| DB1
+IBP -->|DBアクセス| DB2
+IBP -->|外部API| ExtAPI
+
+%% MCP/AI連携
+MCPGW -- MCPリクエスト --> MCP
+MCP -- gRPC/REST --> AIM
+AIM -- gRPC/REST --> MCP
+MCP -- MCPレスポンス --> MCPGW
+MCPGW -- APIレスポンス --> CAPI
+
+%% インフラ連携
+CAPI -.->|デプロイ| K8s
+IAPI -.->|デプロイ| K8s
+IBP -.->|デプロイ| K8s
+K8s -.->|実行基盤| Cloud
+K8s -.->|監視| Mon
+K8s -.->|シークレット| Vault
+K8s -.->|CI/CD| CI
+AGW -.->|監視| Mon
+CAPI -.->|監視| Mon
+IAPI -.->|監視| Mon
+IBP -.->|監視| Mon
+MCPGW -.->|監視| Mon
+
+%% 備考
+classDef infra fill:#e3f2fd,stroke:#90caf9;
+class K8s,Cloud,CI,Vault,Mon infra;
+classDef ai fill:#f3e5f5,stroke:#ba68c8;
+class MCP,AIM ai;
+classDef db fill:#fffde7,stroke:#ffe082;
+class DB1,DB2,ExtAPI db;
+```
+
+---
+
 ## システム構成要素
 
 - **共通基盤**  
@@ -320,7 +434,7 @@ sequenceDiagram
 
 ---
 
-## API管理・バージョニング戦略
+## API管理・バージョン管理戦略
 
 KisoFrameworkでは、APIの長期的な運用・拡張性・後方互換性を担保するため、以下のAPI管理・バージョニング戦略を採用する。
 


### PR DESCRIPTION
- 詳細概念図を追加し、システムの各層（UI層、APIゲートウェイ層、共通基盤API層、個別API層、データ層、AI連携層、インフラ層）の構成を視覚化しました。
- API管理・バージョニング戦略のセクション名を「API管理・バージョニング戦略」から「API管理・バージョン管理戦略」に変更しました。